### PR TITLE
Add color logs

### DIFF
--- a/log.js
+++ b/log.js
@@ -36,31 +36,36 @@ function log (client, messages) {
 
   if (messages.state !== false) {
     unbind.push(sync.on('state', function () {
-      var needAdditionalStyles = true
       var postfix = ''
       var nodeIdString = ''
       var syncStateString = stylePrefix + sync.state + stylePrefix
+      var connectionUrlString = stylePrefix + sync.connection.url + stylePrefix
+      var stylesCount = 1
 
       if (sync.state === 'connecting' && sync.connection.url) {
         nodeIdString = stylePrefix + sync.localNodeId + stylePrefix
         postfix = '. ' + nodeIdString + ' is connecting to ' +
-                  sync.connection.url + '.'
+                  connectionUrlString + '.'
+        stylesCount += 2
       }
 
       if (sync.connected && !prevConnected) {
         nodeIdString = stylePrefix + sync.remoteNodeId + stylePrefix
         postfix = '. Client was connected to ' + nodeIdString + '.'
         prevConnected = true
+        stylesCount++
       } else if (!sync.connected) {
         prevConnected = false
-        if (!postfix) needAdditionalStyles = false
       }
 
-      showMessage(
-          'log',
-          'change state to ' + syncStateString + postfix,
-          boldStyle, '', needAdditionalStyles ? boldStyle : '', ''
-      )
+      var args = ['log', 'state was changed to ' + syncStateString + postfix]
+      if (colorsEnabled) {
+        for (var i = 0; i < stylesCount; i++) {
+          args.push(boldStyle, '')
+        }
+      }
+
+      showMessage.apply(log, args)
     }))
   }
 
@@ -77,21 +82,24 @@ function log (client, messages) {
     unbind.push(sync.log.on('add', function (action, meta) {
       var message
       var actionTypeString = stylePrefix + action.type + stylePrefix
-      var needAdditionalStyles = true
+      var stylesCount = 1
       if (meta.id[1] === sync.localNodeId) {
-        message = 'Action ' + actionTypeString + ' was added to Logux'
-        needAdditionalStyles = false
+        message = 'action ' + actionTypeString + ' was added'
       } else {
         var metaString = stylePrefix + meta.id[1] + stylePrefix
-        message = metaString + ' added action ' + actionTypeString + ' to Logux'
+        message = metaString + ' added action ' + actionTypeString
+        stylesCount++
       }
 
-      showMessage(
-          'log', message,
-          boldStyle, '',
-          needAdditionalStyles ? boldStyle : '', '',
-          action, meta
-      )
+      var args = ['log', message]
+      if (colorsEnabled) {
+        for (var i = 0; i < stylesCount; i++) {
+          args.push(boldStyle, '')
+        }
+      }
+      args.push(action, meta)
+
+      showMessage.apply(log, args)
     }))
   }
 
@@ -100,7 +108,7 @@ function log (client, messages) {
       var actionTypeString = stylePrefix + action.type + stylePrefix
       showMessage(
         'log',
-        'Action ' + actionTypeString + ' was cleaned from Logux',
+        'action ' + actionTypeString + ' was cleaned',
         boldStyle, '', action, meta
       )
     }))

--- a/log.js
+++ b/log.js
@@ -77,13 +77,21 @@ function log (client, messages) {
     unbind.push(sync.log.on('add', function (action, meta) {
       var message
       var actionTypeString = stylePrefix + action.type + stylePrefix
+      var needAdditionalStyles = true
       if (meta.id[1] === sync.localNodeId) {
         message = 'Action ' + actionTypeString + ' was added to Logux'
+        needAdditionalStyles = false
       } else {
-        message = meta.id[1] + ' added action ' + actionTypeString + ' to Logux'
+        var metaString = stylePrefix + meta.id[1] + stylePrefix
+        message = metaString + ' added action ' + actionTypeString + ' to Logux'
       }
 
-      showMessage('log', message, boldStyle, '', action, meta)
+      showMessage(
+          'log', message,
+          boldStyle, '',
+          needAdditionalStyles ? boldStyle : '', '',
+          action, meta
+      )
     }))
   }
 

--- a/log.js
+++ b/log.js
@@ -36,28 +36,30 @@ function log (client, messages) {
 
   if (messages.state !== false) {
     unbind.push(sync.on('state', function () {
+      var needAdditionalStyles = true
       var postfix = ''
       var nodeIdString = ''
       var syncStateString = stylePrefix + sync.state + stylePrefix
 
       if (sync.state === 'connecting' && sync.connection.url) {
-        nodeIdString = stylePrefix + sync.localNodeId
+        nodeIdString = stylePrefix + sync.localNodeId + stylePrefix
         postfix = '. ' + nodeIdString + ' is connecting to ' +
                   sync.connection.url + '.'
       }
 
       if (sync.connected && !prevConnected) {
-        nodeIdString = stylePrefix + sync.remoteNodeId
+        nodeIdString = stylePrefix + sync.remoteNodeId + stylePrefix
         postfix = '. Client was connected to ' + nodeIdString + '.'
         prevConnected = true
       } else if (!sync.connected) {
         prevConnected = false
+        if (!postfix) needAdditionalStyles = false
       }
 
       showMessage(
           'log',
           'change state to ' + syncStateString + postfix,
-          boldStyle, '', boldStyle
+          boldStyle, '', needAdditionalStyles ? boldStyle : '', ''
       )
     }))
   }
@@ -81,7 +83,7 @@ function log (client, messages) {
         message = meta.id[1] + ' added action ' + actionTypeString + ' to Logux'
       }
 
-      showMessage('log', message, boldStyle, action, meta)
+      showMessage('log', message, boldStyle, '', action, meta)
     }))
   }
 
@@ -91,7 +93,7 @@ function log (client, messages) {
       showMessage(
         'log',
         'Action ' + actionTypeString + ' was cleaned from Logux',
-        boldStyle, action, meta
+        boldStyle, '', action, meta
       )
     }))
   }
@@ -100,10 +102,11 @@ function log (client, messages) {
     var args = Array.prototype.slice.call(arguments, 1)
 
     if (colorsEnabled) {
-      args.unshift('color: #ffa200')
-      args.unshift('%cLogux: ')
+      args[0] = '%cLogux:%c ' + args[0]
+      args.splice(1, 0, 'color: #ffa200')
+      args.splice(2, 0, '')
     } else {
-      args.unshift('Logux: ')
+      args[0] = 'Logux: ' + args[0]
     }
 
     console[type].apply(console, args)

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "repository": "logux/logux-status",
   "dependencies": {},
   "devDependencies": {
+    "browser-supports-log-styles": "^1.1.5",
     "docdash": "^0.4.0",
     "eslint": "^3.15.0",
     "eslint-config-logux": "^5.0.1",

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -42,9 +42,8 @@ it('shows connecting state URL', function () {
     test.leftSync.setState('connecting')
 
     expect(console.log).toBeCalledWith(
-      'Logux: ',
-      'change state to connecting. test1 is connecting to ws://ya.ru.',
-      '', '', ''
+      'Logux: change state to connecting. test1 is connecting to ws://ya.ru.',
+      '', '', '', ''
     )
   })
 })
@@ -58,10 +57,14 @@ it('shows Logux prefix with color and make state and nodeId bold', function () {
     test.leftSync.setState('connecting')
 
     expect(console.log).toBeCalledWith(
-      '%cLogux: ',
+      '%cLogux:%c change state to %cconnecting%c. ' +
+      '%ctest1%c is connecting to ws://ya.ru.',
       'color: #ffa200',
-      'change state to %cconnecting%c. %ctest1 is connecting to ws://ya.ru.',
-      'font-weight: bold', '', 'font-weight: bold'
+      '',
+      'font-weight: bold',
+      '',
+      'font-weight: bold',
+      ''
     )
   })
 })
@@ -75,17 +78,46 @@ it('shows server node ID', function () {
     test.leftSync.setState('synchronized')
 
     expect(console.log).toBeCalledWith(
-      'Logux: ',
-      'change state to synchronized. ' +
+      'Logux: change state to synchronized. ' +
       'Client was connected to server.',
-      '', '', ''
+      '', '', '', ''
     )
 
     test.leftSync.connected = false
     test.leftSync.setState('wait')
     expect(console.log).toHaveBeenLastCalledWith(
-        'Logux: ',
-        'change state to wait',
+        'Logux: change state to wait',
+        '', '', '', ''
+    )
+  })
+})
+
+it('shows bold server node ID', function () {
+  return createTest().then(function (test) {
+    log({ sync: test.leftSync }, { color: true })
+
+    test.leftSync.remoteNodeId = 'server'
+    test.leftSync.connected = true
+    test.leftSync.setState('synchronized')
+
+    expect(console.log).toBeCalledWith(
+      '%cLogux:%c change state to %csynchronized%c. ' +
+      'Client was connected to %cserver%c.',
+      'color: #ffa200',
+      '',
+      'font-weight: bold',
+      '',
+      'font-weight: bold',
+      ''
+    )
+
+    test.leftSync.connected = false
+    test.leftSync.setState('wait')
+    expect(console.log).toHaveBeenLastCalledWith(
+        '%cLogux:%c change state to %cwait%c',
+        'color: #ffa200',
+        '',
+        'font-weight: bold',
         '', '', ''
     )
   })
@@ -99,9 +131,8 @@ it('shows state event', function () {
     test.leftSync.emitter.emit('state')
 
     expect(console.log).toBeCalledWith(
-        'Logux: ',
-        'change state to disconnected',
-        '', '', ''
+        'Logux: change state to disconnected',
+        '', '', '', ''
     )
   })
 })
@@ -110,7 +141,19 @@ it('shows error event', function () {
   return createTest().then(function (test) {
     log({ sync: test.leftSync }, { color: false })
     test.left.emitter.emit('error', new SyncError(test.leftSync, 'test'))
-    expect(console.error).toBeCalledWith('Logux: ', 'error: test')
+    expect(console.error).toBeCalledWith('Logux: error: test')
+  })
+})
+
+it('shows colorized error event', function () {
+  return createTest().then(function (test) {
+    log({ sync: test.leftSync }, { color: true })
+    test.left.emitter.emit('error', new SyncError(test.leftSync, 'test'))
+    expect(console.error).toBeCalledWith(
+        '%cLogux:%c error: test',
+        'color: #ffa200',
+        ''
+    )
   })
 })
 
@@ -121,7 +164,7 @@ it('shows server error', function () {
     var error = new SyncError(test.leftSync, 'test', 'type', true)
     test.leftSync.emitter.emit('clientError', error)
 
-    expect(console.error).toBeCalledWith('Logux: ', 'server sent error: test')
+    expect(console.error).toBeCalledWith('Logux: server sent error: test')
   })
 })
 
@@ -131,8 +174,8 @@ it('shows add and clean event', function () {
     return test.leftSync.log.add({ type: 'A' }, { reasons: ['test'] })
       .then(function () {
         expect(console.log).toBeCalledWith(
-          'Logux: ',
-          'Action A was added to Logux',
+          'Logux: Action A was added to Logux',
+          '',
           '',
           { type: 'A' },
           { id: [1, 'test1', 0], reasons: ['test'], time: 1, added: 1 }
@@ -140,8 +183,8 @@ it('shows add and clean event', function () {
         return test.leftSync.log.removeReason('test')
       }).then(function () {
         expect(console.log).toHaveBeenLastCalledWith(
-          'Logux: ',
-          'Action A was cleaned from Logux',
+          'Logux: Action A was cleaned from Logux',
+          '',
           '',
           { type: 'A' },
           { id: [1, 'test1', 0], reasons: [], time: 1, added: 1 }
@@ -156,20 +199,22 @@ it('shows add and clean event and make action type bold', function () {
     return test.leftSync.log.add({ type: 'A' }, { reasons: ['test'] })
       .then(function () {
         expect(console.log).toBeCalledWith(
-          '%cLogux: ',
+          '%cLogux:%c Action %cA%c was added to Logux',
           'color: #ffa200',
-          'Action %cA%c was added to Logux',
+          '',
           'font-weight: bold',
+          '',
           { type: 'A' },
           { id: [1, 'test1', 0], reasons: ['test'], time: 1, added: 1 }
         )
         return test.leftSync.log.removeReason('test')
       }).then(function () {
         expect(console.log).toHaveBeenLastCalledWith(
-          '%cLogux: ',
+          '%cLogux:%c Action %cA%c was cleaned from Logux',
           'color: #ffa200',
-          'Action %cA%c was cleaned from Logux',
+          '',
           'font-weight: bold',
+          '',
           { type: 'A' },
           { id: [1, 'test1', 0], reasons: [], time: 1, added: 1 }
         )
@@ -184,10 +229,11 @@ it('shows add event with action and make action type bold', function () {
     return test.leftSync.log.add({ type: 'B' }, { reasons: ['test'] })
   }).then(function () {
     expect(console.log).toBeCalledWith(
-      '%cLogux: ',
+      '%cLogux:%c test1 added action %cB%c to Logux',
       'color: #ffa200',
-      'test1 added action %cB%c to Logux',
+      '',
       'font-weight: bold',
+      '',
       { type: 'B' },
       { id: [1, 'test1', 0], reasons: ['test'], time: 1, added: 1 }
     )

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -35,7 +35,7 @@ it('shows connecting state URL', function () {
     test.leftSync.connection.url = 'ws://ya.ru'
     test.leftSync.setState('connecting')
 
-    expect(console.log).toBeCalledWith('Logux change state to connecting. ' +
+    expect(console.log).toBeCalledWith('Logux: change state to connecting. ' +
       'test1 is connecting to ws://ya.ru.')
   })
 })
@@ -48,12 +48,12 @@ it('shows server node ID', function () {
     test.leftSync.connected = true
     test.leftSync.setState('synchronized')
 
-    expect(console.log).toBeCalledWith('Logux change state to synchronized. ' +
+    expect(console.log).toBeCalledWith('Logux: change state to synchronized. ' +
       'Client was connected to server.')
 
     test.leftSync.connected = false
     test.leftSync.setState('wait')
-    expect(console.log).toHaveBeenLastCalledWith('Logux change state to wait')
+    expect(console.log).toHaveBeenLastCalledWith('Logux: change state to wait')
   })
 })
 
@@ -64,7 +64,7 @@ it('shows state event', function () {
     test.leftSync.connected = false
     test.leftSync.emitter.emit('state')
 
-    expect(console.log).toBeCalledWith('Logux change state to disconnected')
+    expect(console.log).toBeCalledWith('Logux: change state to disconnected')
   })
 })
 
@@ -72,7 +72,7 @@ it('shows error event', function () {
   return createTest().then(function (test) {
     log({ sync: test.leftSync })
     test.left.emitter.emit('error', new SyncError(test.leftSync, 'test'))
-    expect(console.error).toBeCalledWith('Logux error: test')
+    expect(console.error).toBeCalledWith('Logux: error: test')
   })
 })
 
@@ -83,7 +83,7 @@ it('shows server error', function () {
     var error = new SyncError(test.leftSync, 'test', 'type', true)
     test.leftSync.emitter.emit('clientError', error)
 
-    expect(console.error).toBeCalledWith('Logux server sent error: test')
+    expect(console.error).toBeCalledWith('Logux: server sent error: test')
   })
 })
 
@@ -93,14 +93,14 @@ it('shows add and clean event', function () {
     return test.leftSync.log.add({ type: 'A' }, { reasons: ['test'] })
       .then(function () {
         expect(console.log).toBeCalledWith(
-          'Action A was added to Logux',
+          'Logux: Action A was added to Logux',
           { type: 'A' },
           { id: [1, 'test1', 0], reasons: ['test'], time: 1, added: 1 }
         )
         return test.leftSync.log.removeReason('test')
       }).then(function () {
         expect(console.log).toHaveBeenLastCalledWith(
-          'Action A was cleaned from Logux',
+          'Logux: Action A was cleaned from Logux',
           { type: 'A' },
           { id: [1, 'test1', 0], reasons: [], time: 1, added: 1 }
         )
@@ -115,7 +115,7 @@ it('shows add event with action from different node', function () {
     return test.leftSync.log.add({ type: 'B' }, { reasons: ['test'] })
   }).then(function () {
     expect(console.log).toBeCalledWith(
-      'test1 added action B to Logux',
+      'Logux: test1 added action B to Logux',
       { type: 'B' },
       { id: [1, 'test1', 0], reasons: ['test'], time: 1, added: 1 }
     )

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -3,6 +3,12 @@ var TestTime = require('logux-core').TestTime
 var BaseSync = require('logux-sync').BaseSync
 var TestPair = require('logux-sync').TestPair
 
+jest.mock('browser-supports-log-styles', function () {
+  return function () {
+    return true
+  }
+})
+
 var log = require('../log')
 
 function createTest () {
@@ -29,78 +35,114 @@ afterEach(function () {
 
 it('shows connecting state URL', function () {
   return createTest().then(function (test) {
-    log({ sync: test.leftSync })
+    log({ sync: test.leftSync }, { color: false })
 
     test.leftSync.connected = false
     test.leftSync.connection.url = 'ws://ya.ru'
     test.leftSync.setState('connecting')
 
-    expect(console.log).toBeCalledWith('Logux: change state to connecting. ' +
-      'test1 is connecting to ws://ya.ru.')
+    expect(console.log).toBeCalledWith(
+      'Logux: ',
+      'change state to connecting. test1 is connecting to ws://ya.ru.',
+      '', '', ''
+    )
+  })
+})
+
+it('shows Logux prefix with color and make state and nodeId bold', function () {
+  return createTest().then(function (test) {
+    log({ sync: test.leftSync }, { color: true })
+
+    test.leftSync.connected = false
+    test.leftSync.connection.url = 'ws://ya.ru'
+    test.leftSync.setState('connecting')
+
+    expect(console.log).toBeCalledWith(
+      '%cLogux: ',
+      'color: #ffa200',
+      'change state to %cconnecting%c. %ctest1 is connecting to ws://ya.ru.',
+      'font-weight: bold', '', 'font-weight: bold'
+    )
   })
 })
 
 it('shows server node ID', function () {
   return createTest().then(function (test) {
-    log({ sync: test.leftSync })
+    log({ sync: test.leftSync }, { color: false })
 
     test.leftSync.remoteNodeId = 'server'
     test.leftSync.connected = true
     test.leftSync.setState('synchronized')
 
-    expect(console.log).toBeCalledWith('Logux: change state to synchronized. ' +
-      'Client was connected to server.')
+    expect(console.log).toBeCalledWith(
+      'Logux: ',
+      'change state to synchronized. ' +
+      'Client was connected to server.',
+      '', '', ''
+    )
 
     test.leftSync.connected = false
     test.leftSync.setState('wait')
-    expect(console.log).toHaveBeenLastCalledWith('Logux: change state to wait')
+    expect(console.log).toHaveBeenLastCalledWith(
+        'Logux: ',
+        'change state to wait',
+        '', '', ''
+    )
   })
 })
 
 it('shows state event', function () {
   return createTest().then(function (test) {
-    log({ sync: test.leftSync })
+    log({ sync: test.leftSync }, { color: false })
 
     test.leftSync.connected = false
     test.leftSync.emitter.emit('state')
 
-    expect(console.log).toBeCalledWith('Logux: change state to disconnected')
+    expect(console.log).toBeCalledWith(
+        'Logux: ',
+        'change state to disconnected',
+        '', '', ''
+    )
   })
 })
 
 it('shows error event', function () {
   return createTest().then(function (test) {
-    log({ sync: test.leftSync })
+    log({ sync: test.leftSync }, { color: false })
     test.left.emitter.emit('error', new SyncError(test.leftSync, 'test'))
-    expect(console.error).toBeCalledWith('Logux: error: test')
+    expect(console.error).toBeCalledWith('Logux: ', 'error: test')
   })
 })
 
 it('shows server error', function () {
   return createTest().then(function (test) {
-    log({ sync: test.leftSync })
+    log({ sync: test.leftSync }, { color: false })
 
     var error = new SyncError(test.leftSync, 'test', 'type', true)
     test.leftSync.emitter.emit('clientError', error)
 
-    expect(console.error).toBeCalledWith('Logux: server sent error: test')
+    expect(console.error).toBeCalledWith('Logux: ', 'server sent error: test')
   })
 })
 
 it('shows add and clean event', function () {
   return createTest().then(function (test) {
-    log({ sync: test.leftSync })
+    log({ sync: test.leftSync }, { color: false })
     return test.leftSync.log.add({ type: 'A' }, { reasons: ['test'] })
       .then(function () {
         expect(console.log).toBeCalledWith(
-          'Logux: Action A was added to Logux',
+          'Logux: ',
+          'Action A was added to Logux',
+          '',
           { type: 'A' },
           { id: [1, 'test1', 0], reasons: ['test'], time: 1, added: 1 }
         )
         return test.leftSync.log.removeReason('test')
       }).then(function () {
         expect(console.log).toHaveBeenLastCalledWith(
-          'Logux: Action A was cleaned from Logux',
+          'Logux: ',
+          'Action A was cleaned from Logux',
+          '',
           { type: 'A' },
           { id: [1, 'test1', 0], reasons: [], time: 1, added: 1 }
         )
@@ -108,14 +150,44 @@ it('shows add and clean event', function () {
   })
 })
 
-it('shows add event with action from different node', function () {
+it('shows add and clean event and make action type bold', function () {
+  return createTest().then(function (test) {
+    log({ sync: test.leftSync }, { color: true })
+    return test.leftSync.log.add({ type: 'A' }, { reasons: ['test'] })
+      .then(function () {
+        expect(console.log).toBeCalledWith(
+          '%cLogux: ',
+          'color: #ffa200',
+          'Action %cA%c was added to Logux',
+          'font-weight: bold',
+          { type: 'A' },
+          { id: [1, 'test1', 0], reasons: ['test'], time: 1, added: 1 }
+        )
+        return test.leftSync.log.removeReason('test')
+      }).then(function () {
+        expect(console.log).toHaveBeenLastCalledWith(
+          '%cLogux: ',
+          'color: #ffa200',
+          'Action %cA%c was cleaned from Logux',
+          'font-weight: bold',
+          { type: 'A' },
+          { id: [1, 'test1', 0], reasons: [], time: 1, added: 1 }
+        )
+      })
+  })
+})
+
+it('shows add event with action and make action type bold', function () {
   return createTest().then(function (test) {
     test.leftSync.localNodeId = 'client'
     log({ sync: test.leftSync })
     return test.leftSync.log.add({ type: 'B' }, { reasons: ['test'] })
   }).then(function () {
     expect(console.log).toBeCalledWith(
-      'Logux: test1 added action B to Logux',
+      '%cLogux: ',
+      'color: #ffa200',
+      'test1 added action %cB%c to Logux',
+      'font-weight: bold',
       { type: 'B' },
       { id: [1, 'test1', 0], reasons: ['test'], time: 1, added: 1 }
     )
@@ -128,6 +200,7 @@ it('allows to disable some message types', function () {
       state: false,
       error: false,
       clean: false,
+      color: false,
       add: false
     })
 
@@ -146,7 +219,7 @@ it('allows to disable some message types', function () {
 
 it('returns unbind function', function () {
   return createTest().then(function (test) {
-    var unbind = log({ sync: test.leftSync })
+    var unbind = log({ sync: test.leftSync }, { color: false })
 
     unbind()
     test.left.emitter.emit('error', new Error('test'))

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -175,8 +175,7 @@ it('shows add and clean event', function () {
       .then(function () {
         expect(console.log).toBeCalledWith(
           'Logux: Action A was added to Logux',
-          '',
-          '',
+          '', '', '', '',
           { type: 'A' },
           { id: [1, 'test1', 0], reasons: ['test'], time: 1, added: 1 }
         )
@@ -203,7 +202,7 @@ it('shows add and clean event and make action type bold', function () {
           'color: #ffa200',
           '',
           'font-weight: bold',
-          '',
+          '', '', '',
           { type: 'A' },
           { id: [1, 'test1', 0], reasons: ['test'], time: 1, added: 1 }
         )
@@ -229,8 +228,10 @@ it('shows add event with action and make action type bold', function () {
     return test.leftSync.log.add({ type: 'B' }, { reasons: ['test'] })
   }).then(function () {
     expect(console.log).toBeCalledWith(
-      '%cLogux:%c test1 added action %cB%c to Logux',
+      '%cLogux:%c %ctest1%c added action %cB%c to Logux',
       'color: #ffa200',
+      '',
+      'font-weight: bold',
       '',
       'font-weight: bold',
       '',

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -42,8 +42,8 @@ it('shows connecting state URL', function () {
     test.leftSync.setState('connecting')
 
     expect(console.log).toBeCalledWith(
-      'Logux: change state to connecting. test1 is connecting to ws://ya.ru.',
-      '', '', '', ''
+      'Logux: state was changed to connecting. ' +
+      'test1 is connecting to ws://ya.ru.'
     )
   })
 })
@@ -57,9 +57,11 @@ it('shows Logux prefix with color and make state and nodeId bold', function () {
     test.leftSync.setState('connecting')
 
     expect(console.log).toBeCalledWith(
-      '%cLogux:%c change state to %cconnecting%c. ' +
-      '%ctest1%c is connecting to ws://ya.ru.',
+      '%cLogux:%c state was changed to %cconnecting%c. ' +
+      '%ctest1%c is connecting to %cws://ya.ru%c.',
       'color: #ffa200',
+      '',
+      'font-weight: bold',
       '',
       'font-weight: bold',
       '',
@@ -78,16 +80,14 @@ it('shows server node ID', function () {
     test.leftSync.setState('synchronized')
 
     expect(console.log).toBeCalledWith(
-      'Logux: change state to synchronized. ' +
-      'Client was connected to server.',
-      '', '', '', ''
+      'Logux: state was changed to synchronized. ' +
+      'Client was connected to server.'
     )
 
     test.leftSync.connected = false
     test.leftSync.setState('wait')
     expect(console.log).toHaveBeenLastCalledWith(
-        'Logux: change state to wait',
-        '', '', '', ''
+        'Logux: state was changed to wait'
     )
   })
 })
@@ -101,7 +101,7 @@ it('shows bold server node ID', function () {
     test.leftSync.setState('synchronized')
 
     expect(console.log).toBeCalledWith(
-      '%cLogux:%c change state to %csynchronized%c. ' +
+      '%cLogux:%c state was changed to %csynchronized%c. ' +
       'Client was connected to %cserver%c.',
       'color: #ffa200',
       '',
@@ -114,11 +114,11 @@ it('shows bold server node ID', function () {
     test.leftSync.connected = false
     test.leftSync.setState('wait')
     expect(console.log).toHaveBeenLastCalledWith(
-        '%cLogux:%c change state to %cwait%c',
+        '%cLogux:%c state was changed to %cwait%c',
         'color: #ffa200',
         '',
         'font-weight: bold',
-        '', '', ''
+        ''
     )
   })
 })
@@ -131,8 +131,7 @@ it('shows state event', function () {
     test.leftSync.emitter.emit('state')
 
     expect(console.log).toBeCalledWith(
-        'Logux: change state to disconnected',
-        '', '', '', ''
+        'Logux: state was changed to disconnected'
     )
   })
 })
@@ -168,23 +167,36 @@ it('shows server error', function () {
   })
 })
 
+it('shows bold server error', function () {
+  return createTest().then(function (test) {
+    log({ sync: test.leftSync }, { color: true })
+
+    var error = new SyncError(test.leftSync, 'test', 'type', true)
+    test.leftSync.emitter.emit('clientError', error)
+
+    expect(console.error).toBeCalledWith(
+        '%cLogux:%c server sent error: test',
+        'color: #ffa200',
+        ''
+    )
+  })
+})
+
 it('shows add and clean event', function () {
   return createTest().then(function (test) {
     log({ sync: test.leftSync }, { color: false })
     return test.leftSync.log.add({ type: 'A' }, { reasons: ['test'] })
       .then(function () {
         expect(console.log).toBeCalledWith(
-          'Logux: Action A was added to Logux',
-          '', '', '', '',
+          'Logux: action A was added',
           { type: 'A' },
           { id: [1, 'test1', 0], reasons: ['test'], time: 1, added: 1 }
         )
         return test.leftSync.log.removeReason('test')
       }).then(function () {
         expect(console.log).toHaveBeenLastCalledWith(
-          'Logux: Action A was cleaned from Logux',
-          '',
-          '',
+          'Logux: action A was cleaned',
+          '', '',
           { type: 'A' },
           { id: [1, 'test1', 0], reasons: [], time: 1, added: 1 }
         )
@@ -198,18 +210,18 @@ it('shows add and clean event and make action type bold', function () {
     return test.leftSync.log.add({ type: 'A' }, { reasons: ['test'] })
       .then(function () {
         expect(console.log).toBeCalledWith(
-          '%cLogux:%c Action %cA%c was added to Logux',
+          '%cLogux:%c action %cA%c was added',
           'color: #ffa200',
           '',
           'font-weight: bold',
-          '', '', '',
+          '',
           { type: 'A' },
           { id: [1, 'test1', 0], reasons: ['test'], time: 1, added: 1 }
         )
         return test.leftSync.log.removeReason('test')
       }).then(function () {
         expect(console.log).toHaveBeenLastCalledWith(
-          '%cLogux:%c Action %cA%c was cleaned from Logux',
+          '%cLogux:%c action %cA%c was cleaned',
           'color: #ffa200',
           '',
           'font-weight: bold',
@@ -228,7 +240,7 @@ it('shows add event with action and make action type bold', function () {
     return test.leftSync.log.add({ type: 'B' }, { reasons: ['test'] })
   }).then(function () {
     expect(console.log).toBeCalledWith(
-      '%cLogux:%c %ctest1%c added action %cB%c to Logux',
+      '%cLogux:%c %ctest1%c added action %cB%c',
       'color: #ffa200',
       '',
       'font-weight: bold',

--- a/yarn.lock
+++ b/yarn.lock
@@ -420,6 +420,10 @@ browser-resolve@^1.11.2:
   dependencies:
     resolve "1.1.7"
 
+browser-supports-log-styles@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/browser-supports-log-styles/-/browser-supports-log-styles-1.1.5.tgz#205ca1ba13c4958acded5ef73633fdeed25e8d13"
+
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.0.6.tgz#5e7725dbdef1fd5930d4ebab48567ce451c48a0a"


### PR DESCRIPTION
PR for Issue https://github.com/logux/logux-status/issues/8
Added color logs for browsers with console styles support. Due to sort of tricky logs styling we have to insert styles line right after string with %c symbol. Moreover, if we want to style only one word in the string – it's necessary either split this string at least three parts or use double %c symbol. I've chose the second variant as Safari displays console.log() with more than argument like console.group – in the column, so it will be ugly to split strings to make some words bold