### PR TITLE
Update README info about color logs

### DIFF
--- a/.yaspellerrc
+++ b/.yaspellerrc
@@ -9,6 +9,7 @@
     "BaseSync",
     "Syncable",
     "UX",
-    "favicon"
+    "favicon",
+    "colorized"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ Possible types are: `state`, `error`, `add`, `clean`.
 log(client, { add: false })
 ```
 
+Logux events in browser console are colorized by default, if console styling is supported by browser.
+To disable this feature, set `color` to false in the second argument.
+
+```js
+log(client, { color: false })
+```
+
 It return a function to disable itself.
 
 ```js


### PR DESCRIPTION
Missed it in https://github.com/logux/logux-status/pull/12