### PR TITLE
logux-badge:: background color fix for demo, more consistent README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,16 +157,15 @@ This feature will be useful for application users to be aware of
 current Logux server connection status. To make sure that they won’t
 lose any unsaved data because of server malfunctioning.
 
-In the second argument you can pass object to configure widget appearance
-in different states.
+Use second argument to configure widget appearance in different states.
 
-First of all you must define base styles for widget and styles
-in different states. Icon for widget injecting as background image,
+First of all you must define base styles for widget and optional styles
+for different states. Icon for widget injecting as background image,
 so remember about left padding for appropriate positioning.
 
 Possible states are: `synchronized`, `disconnected`, `wait`, `sending`,
 `connecting`, `error`, `protocolError`. Use states as keys in `styles`
-object with value of object with desired styles.
+object to define desired styles for states.
 
 ```js
   styles: {

--- a/badge/default.js
+++ b/badge/default.js
@@ -17,7 +17,6 @@ module.exports = {
     color: '#fff',
     fontFamily: 'Helvetica Neue, sans-serif',
     zIndex: '999',
-    backgroundColor: '#000',
     backgroundPosition: '1.2em center',
     backgroundRepeat: 'no-repeat',
     backgroundSize: '1.8em'
@@ -29,22 +28,27 @@ module.exports = {
   },
   synchronized: {
     display: 'block',
+    backgroundColor: '#000',
     backgroundImage: 'url(' + success + ')'
   },
   disconnected: {
     display: 'block',
+    backgroundColor: '#000',
     backgroundImage: 'url(' + offline + ')'
   },
   wait: {
     display: 'block',
+    backgroundColor: '#000',
     backgroundImage: 'url(' + offline + ')'
   },
   sending: {
     display: 'block',
+    backgroundColor: '#000',
     backgroundImage: 'url(' + refresh + ')'
   },
   connecting: {
     display: 'block',
+    backgroundColor: '#000',
     backgroundImage: 'url(' + refresh + ')'
   },
   error: {
@@ -54,6 +58,7 @@ module.exports = {
   },
   protocolError: {
     display: 'block',
+    backgroundColor: '#000',
     backgroundImage: 'url(' + refresh + ')'
   }
 }


### PR DESCRIPTION
It's really not a big deal, but i think that badge styles is not quite correct for demo page because, after error we're getting red-backgrounded badge for any state. So here a little fix. 
Also small refactoring of README.md for more consistent description.